### PR TITLE
Added default copilot.local DNS redirection.

### DIFF
--- a/copilot/plugins/dns/config.py
+++ b/copilot/plugins/dns/config.py
@@ -13,7 +13,11 @@ class ConfigWriter(Config):
         super(ConfigWriter, self).__init__()
         log.debug("Initializing dns config writer.")
         self.config_type = "dns"
-        self.header = "[A]\n"
+        # This copilot.local redirection is needed by default to combat ISP redirection
+        # ISP's like verizon, much like this plugin, do DNS-redirection
+        # They often do it for advertising, in fact, they do it at my apartment
+        # This has finaly been useful, it helped my ID the bug that forced this change.
+        self.header = "[A]\n*.copilot.local = 192.168.12.1\n"
 
     def add_rule(self, rule):
         action, target, sub = rule[0], rule[1], rule[2]

--- a/copilot/plugins/dns/start
+++ b/copilot/plugins/dns/start
@@ -7,16 +7,14 @@ readonly pid_file="/tmp/dnschef.pid"
 start_dnschef() {
     if [[ -e "$custom_profile" ]]; then
         echo "Starting with a custom DNSChef profile."
-        #Write PID to custom file in 5 seconds for later killing
-        $(sleep 5 && echo $(pgrep -f python.*dnschef) > "$pid_file") &
-        "$command" --file="$custom_profile"
     else
         echo "Starting with an empty DNSChef profile."
-        #Write PID to custom file in 5 seconds for later killing
-        $(sleep 5 && echo $(pgrep -f python.*dnschef) > "$pid_file") &
-        "$command"
-
+        printf '[A]\n*.copilot.local = 192.168.12.1' > "$custom_profile"
     fi
+
+    #Write PID to custom file in 5 seconds for later killing
+    $(sleep 5 && echo $(pgrep -f python.*dnschef) > "$pid_file") &
+    "$command" --file="$custom_profile"
 }
 
 kill_old() {


### PR DESCRIPTION
ISP's like verizon, much like this plugin, do DNS-redirection. They
often do it for advertising, in fact, they do it at my apartment. This
has finaly been useful as it helped my ID that when ad based DNS
redirection is occuring the copilot.local webpage will not be
accessible. The solution seems to be to have the dns redirection on by
default for the copilot.local page. Ironically, copilot.local DNS
redirection is needed by default to combat ISP redirection.
