### PR TITLE
Fixed issue #100 bcrypt install error

### DIFF
--- a/install
+++ b/install
@@ -79,6 +79,7 @@ install_flask_deps() {
 
 install_flask() {
     #install flask & WTForms
+    apt-get -y install libffi-dev
     pip install flask
     pip install flask-wtf
     pip install SQLAlchemy


### PR DESCRIPTION
Fixes install error that came from not having libffi-dev installed.
